### PR TITLE
etna.h: include other headers from the same directory

### DIFF
--- a/src/etna.h
+++ b/src/etna.h
@@ -27,10 +27,10 @@
 #ifndef H_ETNA
 #define H_ETNA
 
-#include <common.xml.h>
-#include <cmdstream.xml.h>
-#include <etna_util.h>
-#include <viv.h>
+#include "common.xml.h"
+#include "cmdstream.xml.h"
+#include "etna_util.h"
+#include "viv.h"
 
 #include <stdint.h>
 #include <stdlib.h>


### PR DESCRIPTION
Allows us to do #include <etnaviv/etna.h> instad of
-I/usr/include/etnaviv + #include <etna.h> when installed.